### PR TITLE
Resolve build error on modern gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 all:
 	-rm ./hungry
-	gcc -O3 -Wall -Wextra -Werror -Wpedantic ./hungry.c -o ./hungry
+	gcc -O3 -Wall -Wextra -Werror -Wno-error=unused-but-set-variable -Wpedantic ./hungry.c -o ./hungry


### PR DESCRIPTION
On modern versions of gcc, declaring a variable without using it is considered to be a warning.

Declaring `p` is necessary in order to allocate , but using `p` is outside the scope of hungry. So in this use-case, I think it is acceptable to ignore the warning.